### PR TITLE
fix: replace deprecated v2.ToTensor with v2.ToImage() and v2.ToDtype()

### DIFF
--- a/soups/run_test_multiple_checkpoints.py
+++ b/soups/run_test_multiple_checkpoints.py
@@ -44,7 +44,8 @@ def test_multiple_checkpoints(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],

--- a/soups/run_test_with_model_soups.py
+++ b/soups/run_test_with_model_soups.py
@@ -89,7 +89,8 @@ def test_with_model_soups(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],

--- a/soups/self_influence.py
+++ b/soups/self_influence.py
@@ -59,7 +59,8 @@ def self_influence(args: argparse.Namespace) -> None:
     train_transforms = v2.Compose([
         v2.RandomResizedCrop(size=args.train_crop_size),
         v2.RandomHorizontalFlip(p=0.5),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],
@@ -68,7 +69,8 @@ def self_influence(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],

--- a/soups/train.py
+++ b/soups/train.py
@@ -54,7 +54,8 @@ def train_model(args: argparse.Namespace) -> None:
     train_transforms = v2.Compose([
         v2.RandomResizedCrop(size=args.train_crop_size),
         v2.RandomHorizontalFlip(p=0.5),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],
@@ -63,7 +64,8 @@ def train_model(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],

--- a/soups/train_with_co_teaching.py
+++ b/soups/train_with_co_teaching.py
@@ -49,7 +49,8 @@ def train_model(args: argparse.Namespace) -> None:
     train_transforms = v2.Compose([
         v2.RandomResizedCrop(size=args.train_crop_size),
         v2.RandomHorizontalFlip(p=0.5),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],
@@ -58,7 +59,8 @@ def train_model(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],

--- a/soups/visualize_with_mds.py
+++ b/soups/visualize_with_mds.py
@@ -71,7 +71,8 @@ def visualize_predictions(args: argparse.Namespace) -> None:
     eval_transforms = v2.Compose([
         v2.Resize(size=args.eval_resize_size),
         v2.CenterCrop(size=args.eval_crop_size),
-        v2.ToTensor(),
+        v2.ToImage(),
+        v2.ToDtype(torch.float32, scale=True),
         v2.Normalize(
             mean=[0.485, 0.456, 0.406],
             std=[0.229, 0.224, 0.225],


### PR DESCRIPTION
See: https://docs.pytorch.org/vision/main/generated/torchvision.transforms.v2.ToTensor.html

Look like there are some issues with scaling making the results are not the same: https://github.com/mrdbourke/pytorch-deep-learning/issues/701